### PR TITLE
Correcting the broken link in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Guidelines for Contributors
 Please read the following documents if you are considering contributing to this project.
-* [Code of conduct](../CODE_OF_CONDUCT.md)
+* [Code of conduct](/CODE_OF_CONDUCT.md)
 * Contributing wiki page (coming soon!)
 * Code and style guides (if you are a programmer, coming soon!)


### PR DESCRIPTION
# Correcting the broken link in CONTRIBUTING.md

## Description

The file CONTRIBUTING.md contained a broken relative link. Copilot has fixed the problem.
Original message:
```
The link to CODE_OF_CONDUCT.md in docs/CONTRIBUTING.md used a relative path that fails in GitHub's markdown renderer.

Changed from relative path ../CODE_OF_CONDUCT.md to absolute repository path /CODE_OF_CONDUCT.md. Absolute paths from repo root are GitHub's recommended practice for cross-file references and work consistently regardless of the source file's location.
```

## Type of Change (check one or more)
* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [x] Documentation update
* [ ] Other (please describe):

## Commits included in this pull request
```
+(dev/repo/setup)
|\
| +- "Initial plan"(copilot/fix-contributing-md-link)
| |
| +-"Fix broken link in CONTRIBUTING.md by using absolute path"(copilot/fix-contributing-md-link)
|/
*-"Fix broken link in CONTRIBUTING.md"(dev/repo/setup)
|
^ "Correcting the broken link in CONTRIBUTING.md"(dev/repo/setup to main)
```

## Checklist
* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] New and existing unit tests pass locally with my changes

## Summary by Sourcery

Documentation:
- Update CONTRIBUTING documentation to reference CODE_OF_CONDUCT.md with a GitHub-compatible absolute link.